### PR TITLE
typo in the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ k-Nearest Neighbor Information Estimator
 
 This is a Python package for kNN-based estimator of (multivariate) mutual information from high dimensional samples
 
-Reference: http://arxig.org/abs/1604.03006
+Reference: http://arxiv.org/abs/1604.03006
 
 Read readme.pdf for more details
 


### PR DESCRIPTION
`arxig` should be `arxiv`.